### PR TITLE
Docker pipeline with no artifacts

### DIFF
--- a/.github/workflows/build-test-deploy-docker.yml
+++ b/.github/workflows/build-test-deploy-docker.yml
@@ -118,4 +118,4 @@ jobs:
           image_name=${{ steps.build-docker-image.outputs.image_name }}
           full_image_name="${ECR_REGISTRY}/${image_name}"
           docker image tag $image_name $full_image_name
-          # docker push $new_tag
+          docker push $new_tag


### PR DESCRIPTION
Added a new workflow job that can build/test/deploy docker images without passing artifacts, but requires the docker build steps to run after python tests have finished instead of at the same time, slowing down the pipeline.