### PR TITLE
Explicitly set --secret when building private repos

### DIFF
--- a/.github/workflows/build-test-deploy-docker.yml
+++ b/.github/workflows/build-test-deploy-docker.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           echo "${{ steps.app-token.outputs.token }}" | gh auth login --with-token
           gh auth setup-git
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: |
           if [ ${{ inputs.use_uv }} = true ]; then
@@ -108,12 +109,8 @@ jobs:
         run: |
           IMAGE_NAME=${{ inputs.image_name }}:${PACKAGE_VERSION}
 
-          if [ ${{ inputs.private_repos }} = true ]; then
-            export GH_TOKEN=${{ steps.app-token.outputs.token }}
-          fi
-
           echo "IMAGE_NAME: ${IMAGE_NAME}"
-          docker build -t $IMAGE_NAME .
+          docker build -t $IMAGE_NAME ${GH_TOKEN:+--secret id=GH_TOKEN} .
 
           echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
It turns out we need to set the GH_TOKEN secret explicitly on the command line when doing `docker build`. I did try building locally and it worked fine, so I'm not sure what was up with that. This changes the workflow to set the environment variable in the "Set up access for private repos" step, and then do a little bash substitution magic to set the appropriate options when doing the Docker build.