### PR TITLE
Use more general way to specify Docker options

### DIFF
--- a/.github/workflows/build-test-deploy-docker.yml
+++ b/.github/workflows/build-test-deploy-docker.yml
@@ -39,13 +39,24 @@ on:
         required: false
         type: string
         default: ""
-      docker_target:
-        description: "Optional Docker build target (e.g. prod)"
+      tag_suffix:
+        description: "Optional suffix appended to the image tag (e.g. -variant)"
         required: false
         type: string
         default: ""
-      tag_suffix:
-        description: "Optional suffix appended to the image tag (e.g. -variant)"
+      docker_args:
+        description: |
+          Extra docker flags separated by newlines.
+
+          This is useful for specifying a custom build target and/or
+          values for ARGs in Dockerfiles.  For example:
+
+          docker_args: |
+            --build-arg=FOO=option value with spaces
+            --target=my-target
+
+          Double quotes will break the interpolation, but are not necessary
+          since each command-line argument is separated by newlines
         required: false
         type: string
         default: ""
@@ -135,13 +146,10 @@ jobs:
         run: |
           IMAGE_NAME=${{ inputs.image_name }}:${PACKAGE_VERSION}${{ inputs.tag_suffix }}
 
-          target_args=""
-          if [ -n "${{ inputs.docker_target }}" ]; then
-            target_args="--target ${{ inputs.docker_target }}"
-          fi
+          readarray -t docker_args <<< "${{ inputs.docker_args }}"
 
           echo "IMAGE_NAME: ${IMAGE_NAME}"
-          docker build $target_args -t $IMAGE_NAME ${GH_TOKEN:+--secret id=GH_TOKEN} .
+          docker build "${docker_args[@]}" ${GH_TOKEN:+--secret id=GH_TOKEN} -t $IMAGE_NAME .
 
           echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
We subsume the docker_target input into a new docker_args one.  This
gives a robust way to specify extra options to the Docker build, like
--build-arg as well as --target.
